### PR TITLE
bugfix(vouch-proxy): Fix missing redirect_uri caused by inconsistent oauth.Config across multiple pods

### DIFF
--- a/handlers/login.go
+++ b/handlers/login.go
@@ -254,7 +254,7 @@ func oauthLoginURL(r *http.Request, session sessions.Session) string {
 		return cfg.OAuthClient.AuthCodeURL(state, oauth2.SetAuthURLParam("response_type", "id"))
 	}
 
-	// Pass by value, avoid modifying global variable
+	// Avoid modifying global variable, copy the value of global OauthClient to local variable
 	oauthClient := *cfg.OAuthClient
 	if oauthClient.Scopes != nil {
 		// clone array content

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -256,6 +256,10 @@ func oauthLoginURL(r *http.Request, session sessions.Session) string {
 
 	// Pass by value, avoid modifying global variable
 	oauthClient := *cfg.OAuthClient
+	if oauthClient.Scopes != nil {
+		// clone array content
+		oauthClient.Scopes = append([]string{}, cfg.OAuthClient.Scopes...)
+	}
 
 	// cfg.OAuthClient.RedirectURL is set in cfg
 	// this checks the multiple redirect case for multiple matching domains

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -254,6 +254,9 @@ func oauthLoginURL(r *http.Request, session sessions.Session) string {
 		return cfg.OAuthClient.AuthCodeURL(state, oauth2.SetAuthURLParam("response_type", "id"))
 	}
 
+	// Pass by value, avoid modifying global variable
+	oauthClient := *cfg.OAuthClient
+
 	// cfg.OAuthClient.RedirectURL is set in cfg
 	// this checks the multiple redirect case for multiple matching domains
 	if len(cfg.GenOAuth.RedirectURLs) > 0 {
@@ -264,7 +267,7 @@ func oauthLoginURL(r *http.Request, session sessions.Session) string {
 			if strings.Contains(v, domain) {
 				found = true
 				log.Debugf("/login callback_url set to %s", v)
-				cfg.OAuthClient.RedirectURL = v
+				oauthClient.RedirectURL = v
 				break
 			}
 		}
@@ -281,7 +284,7 @@ func oauthLoginURL(r *http.Request, session sessions.Session) string {
 	if cfg.OAuthopts != nil {
 		opts = append(opts, cfg.OAuthopts...)
 	}
-	return cfg.OAuthClient.AuthCodeURL(state, opts...)
+	return oauthClient.AuthCodeURL(state, opts...)
 }
 
 var regExJustAlphaNum, _ = regexp.Compile("[^a-zA-Z0-9]+")

--- a/pkg/providers/common/common.go
+++ b/pkg/providers/common/common.go
@@ -33,7 +33,7 @@ func Configure() {
 
 // PrepareTokensAndClient setup the client, usually for a UserInfo request
 func PrepareTokensAndClient(r *http.Request, ptokens *structs.PTokens, setProviderToken bool, opts ...oauth2.AuthCodeOption) (*http.Client, *oauth2.Token, error) {
-	// Pass by value, avoid modifying global variable
+	// Avoid modifying global variable, copy the value of global OauthClient to local variable
 	oauthClient := *cfg.OAuthClient
 	if oauthClient.Scopes != nil {
 		// clone array content

--- a/pkg/providers/common/common.go
+++ b/pkg/providers/common/common.go
@@ -35,6 +35,10 @@ func Configure() {
 func PrepareTokensAndClient(r *http.Request, ptokens *structs.PTokens, setProviderToken bool, opts ...oauth2.AuthCodeOption) (*http.Client, *oauth2.Token, error) {
 	// Pass by value, avoid modifying global variable
 	oauthClient := *cfg.OAuthClient
+	if oauthClient.Scopes != nil {
+		// clone array content
+		oauthClient.Scopes = append([]string{}, cfg.OAuthClient.Scopes...)
+	}
 
 	if len(cfg.GenOAuth.RedirectURLs) > 0 {
 		found := false


### PR DESCRIPTION
Vouch proxy intermittently throws this error on multi pods multi URLs setup:

`/auth Error while retrieving user info after successful login at the OAuth provider: oauth2: cannot fetch token: 400 Bad Request Response: { "error": "invalid_request", "error_description": "Missing parameter: redirect_uri" }`

End users will get this 400 error when that happens.

https://p.cermati.com/T83284