### PR TITLE
fix(vouch-proxy): fix cookie size too big

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -115,6 +115,7 @@ func AuthStateHandler(w http.ResponseWriter, r *http.Request) {
 		aud := domains.Matches(u.Host)
 		if aud == "" {
 			responses.Error403(w, r, fmt.Errorf("/auth Requested Host %s is not whitelisted", u.Host))
+			return
 		}
 
 		tokenstring, err = jwtmanager.NewVPJWTWithAud(user, customClaims, ptokens, aud)

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -106,8 +106,17 @@ func AuthStateHandler(w http.ResponseWriter, r *http.Request) {
 	if requestedURL == "" {
 		tokenstring, err = jwtmanager.NewVPJWT(user, customClaims, ptokens)
 	} else {
-		u, _ := url.Parse(requestedURL)
+		u, err1 := url.Parse(requestedURL)
+		if err1 != nil {
+			responses.Error400(w, r, fmt.Errorf("/auth requested URL from cookie is not valid: %w", err))
+			return
+		}
+
 		aud := domains.Matches(u.Host)
+		if aud == "" {
+			responses.Error403(w, r, fmt.Errorf("/auth Requested Host %s is not whitelisted", u.Host))
+		}
+
 		tokenstring, err = jwtmanager.NewVPJWTWithAud(user, customClaims, ptokens, aud)
 	}
 

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -108,7 +108,7 @@ func AuthStateHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		u, err1 := url.Parse(requestedURL)
 		if err1 != nil {
-			responses.Error400(w, r, fmt.Errorf("/auth requested URL from cookie is not valid: %w", err))
+			responses.Error400(w, r, fmt.Errorf("/auth requested URL from cookie is not valid: %w", err1))
 			return
 		}
 

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -13,6 +13,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/cookie"
@@ -105,7 +106,8 @@ func AuthStateHandler(w http.ResponseWriter, r *http.Request) {
 	if requestedURL == "" {
 		tokenstring, err = jwtmanager.NewVPJWT(user, customClaims, ptokens)
 	} else {
-		aud := domains.Matches(requestedURL)
+		u, _ := url.Parse(requestedURL)
+		aud := domains.Matches(u.Host)
 		tokenstring, err = jwtmanager.NewVPJWTWithAud(user, customClaims, ptokens, aud)
 	}
 

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -76,6 +76,11 @@ func audience() string {
 
 // NewVPJWT issue a signed Vouch Proxy JWT for a user
 func NewVPJWT(u structs.User, customClaims structs.CustomClaims, ptokens structs.PTokens) (string, error) {
+	return NewVPJWTWithAud(u, customClaims, ptokens, aud)
+}
+
+// NewVPNewVPJWTWithAudJWT issue a signed Vouch Proxy JWT for a user with custom aud
+func NewVPJWTWithAud(u structs.User, customClaims structs.CustomClaims, ptokens structs.PTokens, audience string) (string, error) {
 	// User`token`
 	// u.PrepareUserData()
 	claims := VouchClaims{
@@ -86,7 +91,7 @@ func NewVPJWT(u structs.User, customClaims structs.CustomClaims, ptokens structs
 		StandardClaims,
 	}
 
-	claims.Audience = aud
+	claims.Audience = audience
 	claims.ExpiresAt = time.Now().Add(time.Minute * time.Duration(cfg.Cfg.JWT.MaxAge)).Unix()
 
 	// https://github.com/vouch/vouch-proxy/issues/287

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -79,7 +79,7 @@ func NewVPJWT(u structs.User, customClaims structs.CustomClaims, ptokens structs
 	return NewVPJWTWithAud(u, customClaims, ptokens, aud)
 }
 
-// NewVPNewVPJWTWithAudJWT issue a signed Vouch Proxy JWT for a user with custom aud
+// NewVPJWTWithAud issue a signed Vouch Proxy JWT for a user with custom aud
 func NewVPJWTWithAud(u structs.User, customClaims structs.CustomClaims, ptokens structs.PTokens, audience string) (string, error) {
 	// User`token`
 	// u.PrepareUserData()


### PR DESCRIPTION
In current implementation, vouch proxy will send all value in `config.domains` as `aud` in encrypted JWT. `aud` in vouch lua library will be used to validate if current host subdomains matches any registered domains in vouch-proxy config. However, our config.domains are growing and it makes the cookie variable size too big so the browser reject it.

This change will significantly reduce the size of JWT with only including requester host as aud
