### PR TITLE
feat: add strict_domain_check config attribute to be used in GET /login

### DIFF
--- a/handlers/login.go
+++ b/handlers/login.go
@@ -228,7 +228,13 @@ func getValidRequestedURL(r *http.Request) (string, error) {
 
 	hostname := u.Hostname()
 	if cfg.GenOAuth.Provider != cfg.Providers.IndieAuth {
-		d := domains.Matches(hostname)
+		var d string
+		if cfg.Cfg.StrictDomainCheck {
+			d = domains.MatchesStrict(hostname)
+		} else {
+			d = domains.Matches(hostname)
+		}
+
 		if d == "" {
 			inCookieDomain := (hostname == cfg.Cfg.Cookie.Domain || strings.HasSuffix(hostname, "."+cfg.Cfg.Cookie.Domain))
 			if cfg.Cfg.Cookie.Domain == "" || !inCookieDomain {

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -43,21 +43,22 @@ import (
 // though most of the time envconfig will use the struct key's name: VOUCH_PORT VOUCH_JWT_MAXAGE
 // default values should be set in .defaults.yml
 type Config struct {
-	LogLevel      string   `mapstructure:"logLevel"`
-	Listen        string   `mapstructure:"listen"`
-	Port          int      `mapstructure:"port"`
-	SocketMode    int      `mapstructure:"socket_mode"`
-	SocketGroup   string   `mapstructure:"socket_group"`
-	DocumentRoot  string   `mapstructure:"document_root" envconfig:"document_root"`
-	WriteTimeout  int      `mapstructure:"writeTimeout"`
-	ReadTimeout   int      `mapstructure:"readTimeout"`
-	IdleTimeout   int      `mapstructure:"idleTimeout"`
-	Domains       []string `mapstructure:"domains"`
-	WhiteList     []string `mapstructure:"whitelist"`
-	TeamWhiteList []string `mapstructure:"teamWhitelist"`
-	AllowAllUsers bool     `mapstructure:"allowAllUsers"`
-	PublicAccess  bool     `mapstructure:"publicAccess"`
-	TLS           struct {
+	LogLevel          string   `mapstructure:"logLevel"`
+	Listen            string   `mapstructure:"listen"`
+	Port              int      `mapstructure:"port"`
+	SocketMode        int      `mapstructure:"socket_mode"`
+	SocketGroup       string   `mapstructure:"socket_group"`
+	DocumentRoot      string   `mapstructure:"document_root" envconfig:"document_root"`
+	WriteTimeout      int      `mapstructure:"writeTimeout"`
+	ReadTimeout       int      `mapstructure:"readTimeout"`
+	IdleTimeout       int      `mapstructure:"idleTimeout"`
+	Domains           []string `mapstructure:"domains"`
+	StrictDomainCheck bool     `mapstructure:"strict_domain_check"`
+	WhiteList         []string `mapstructure:"whitelist"`
+	TeamWhiteList     []string `mapstructure:"teamWhitelist"`
+	AllowAllUsers     bool     `mapstructure:"allowAllUsers"`
+	PublicAccess      bool     `mapstructure:"publicAccess"`
+	TLS               struct {
 		Cert    string `mapstructure:"cert"`
 		Key     string `mapstructure:"key"`
 		Profile string `mapstructure:"profile"`

--- a/pkg/domains/domains.go
+++ b/pkg/domains/domains.go
@@ -47,6 +47,25 @@ func Matches(s string) string {
 	return ""
 }
 
+// MatchesStrict returns one of the domains we're configured for with strict comparison (not matching *.domain.com)
+func MatchesStrict(s string) string {
+	if strings.Contains(s, ":") {
+		// then we have a port and we just want to check the host
+		split := strings.Split(s, ":")
+		log.Debugf("removing port from %s to test domain %s", s, split[0])
+		s = split[0]
+	}
+
+	for i, v := range cfg.Cfg.Domains {
+		if s == v {
+			log.Debugf("domain %s matched array value at [%d]=%v", s, i, v)
+			return v
+		}
+	}
+	log.Warnf("domain %s not found in any domains %v", s, cfg.Cfg.Domains)
+	return ""
+}
+
 // IsUnderManagement check if an email is under vouch-managed domain
 func IsUnderManagement(email string) bool {
 	split := strings.Split(email, "@")

--- a/pkg/domains/domains_test.go
+++ b/pkg/domains/domains_test.go
@@ -11,9 +11,9 @@ OR CONDITIONS OF ANY KIND, either express or implied.
 package domains
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 )
 
@@ -49,4 +49,13 @@ func TestMatches(t *testing.T) {
 	assert.Equal(t, "sub.test.mydomain.com", Matches("sub.test.mydomain.com"))
 	assert.Equal(t, "sub.test.mydomain.com", Matches("subsub.sub.test.mydomain.com"))
 	assert.Equal(t, "test.mydomain.com", Matches("other.test.mydomain.com"))
+}
+
+func TestMatchesStrict(t *testing.T) {
+	assert.Equal(t, "vouch.github.io", MatchesStrict("vouch.github.io"))
+	assert.Equal(t, "", MatchesStrict("sub.vouch.github.io"))
+	assert.Equal(t, "", MatchesStrict("a-different-vouch.github.io"))
+
+	assert.Equal(t, "", MatchesStrict("mydomain.com"))
+
 }


### PR DESCRIPTION
### Background:
In current setup if we want to register a subdomain to vouch we need to configure it on openresty and vouch-proxy config. Sometime we forgot to configure the vouch proxy part (or developers just add it without telling infra team). When that happen they will be redirected to any subdomain (usually the first) that share a domain suffix. For example from grafana.cermati.com to jenkins.cermati.com. It is because the request hostname are checked for matching suffix domain. The problem is we must include the top level domain (e.g `cermati.com`)  because it will be used for [email checking](https://github.com/cermati/vouch-proxy/blob/strict_domain_checking/pkg/domains/domains.go#L70). 
The logic to get redirect URL is as follow:
- Request URL will be compared against `Config.Domains` to check for matching domain.
- The returned domain will be used to search for `callback_urls` using `strings.Contains`, which if the returned domain is TLD we will guaranteed to get a redirect URL.

### Changes:
Add `strict_domain_check` attribute in config to indicates that we need to use strict comparison on subdomain matching. If the subdomain is not match it will send 400 response (instead of redirecting to random URL)


