### PR TITLE
feat(vouch-proxy): add previous URL link in 400 response template

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -63,10 +63,18 @@ func AuthStateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// get the originally requested URL so we can send them on their way
+	requestedURL := session.Values["requestedURL"].(string)
+
+	var responsesOptions []responses.Option
+	if requestedURL != "" {
+		responsesOptions = append(responsesOptions, responses.WithPrevURLOption(requestedURL))
+	}
+
 	// is the nonce "state" valid?
 	queryState := r.URL.Query().Get("state")
 	if session.Values["state"] != queryState {
-		responses.Error400(w, r, fmt.Errorf("/auth Invalid session state: stored %s, returned %s", session.Values["state"], queryState))
+		responses.Error400(w, r, fmt.Errorf("/auth Invalid session state: stored %s, returned %s", session.Values["state"], queryState), responsesOptions...)
 		return
 	}
 
@@ -85,7 +93,7 @@ func AuthStateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := getUserInfo(r, &user, &customClaims, &ptokens, authCodeOptions...); err != nil {
-		responses.Error400(w, r, fmt.Errorf("/auth Error while retrieving user info after successful login at the OAuth provider: %w", err))
+		responses.Error400(w, r, fmt.Errorf("/auth Error while retrieving user info after successful login at the OAuth provider: %w", err), responsesOptions...)
 		return
 	}
 	log.Debugf("/auth/{state}/ Claims from userinfo: %+v", customClaims)
@@ -97,9 +105,6 @@ func AuthStateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// SUCCESS!! they are authorized
-
-	// get the originally requested URL so we can send them on their way
-	requestedURL := session.Values["requestedURL"].(string)
 
 	// issue the jwt
 	var tokenstring string

--- a/pkg/responses/options.go
+++ b/pkg/responses/options.go
@@ -1,0 +1,11 @@
+package responses
+
+// Option is an option type for responses package
+type Option func(idx *Index)
+
+// WithPrevURLOption sets previous URL to be used in response template
+func WithPrevURLOption(prevURL string) Option {
+	return func(idx *Index) {
+		idx.PrevURL = prevURL
+	}
+}

--- a/pkg/responses/responses.go
+++ b/pkg/responses/responses.go
@@ -27,6 +27,7 @@ type Index struct {
 	TestURLs     []string
 	Testing      bool
 	DocumentRoot string
+	PrevURL      string
 }
 
 var (
@@ -56,12 +57,18 @@ func RenderIndex(w http.ResponseWriter, msg string) {
 
 // renderError html error page
 // something terse for the end user
-func renderError(w http.ResponseWriter, msg string, status int) {
+func renderError(w http.ResponseWriter, msg string, status int, opts ...Option) {
 	log.Debugf("rendering error for user: %s", msg)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(status)
-	if err := indexTemplate.Execute(w, &Index{Msg: msg, DocumentRoot: cfg.Cfg.DocumentRoot}); err != nil {
+
+	idx := &Index{Msg: msg, DocumentRoot: cfg.Cfg.DocumentRoot}
+	for _, o := range opts {
+		o(idx)
+	}
+
+	if err := indexTemplate.Execute(w, idx); err != nil {
 		log.Error(err)
 	}
 }
@@ -85,9 +92,9 @@ func Redirect302(w http.ResponseWriter, r *http.Request, rURL string) {
 }
 
 // Error400 Bad Request
-func Error400(w http.ResponseWriter, r *http.Request, e error) {
+func Error400(w http.ResponseWriter, r *http.Request, e error, opts ...Option) {
 	cancelClearSetError(w, r, e)
-	renderError(w, "400 Bad Request", http.StatusBadRequest)
+	renderError(w, "400 Bad Request", http.StatusBadRequest, opts...)
 }
 
 // Error401 Unauthorized, the standard error returned when failing /validate

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -40,6 +40,11 @@ All 302 redirects will be captured and presented as links here
 {{ end }}
 </ul>
 {{ end }}
+{{ if .PrevURL }}
+<div>
+<p>Try revisiting this <a href="{{ .PrevURL}}">previous URL</a></p>
+</div>
+{{ end }}
 <div class="bottom">
 For support, please contact your network administrator or whomever configured Nginx to use Vouch Proxy.
 <p/>


### PR DESCRIPTION
Related Task: 
- https://p.cermati.com/T114857
- https://p.cermati.com/T131776

Sometime user left the oauth page too long that makes the code challenge failed. I add link to previous URL so the user can just restart the process without losing the URL
